### PR TITLE
fix issue where pipelines view does not represent failing jobs within it

### DIFF
--- a/src/static/js/web-cctray.js
+++ b/src/static/js/web-cctray.js
@@ -99,6 +99,29 @@
 		    return obj;
 	  }
 
+    function boxFromJobs(job_names, xitems) {
+        var box = xitems[job_names[0]]; // initialize box to the first job
+        job_names.slice(1).forEach(function(job_name) {
+            // override box if this job's lastBuildStatus is more fail-y than the existing one (i.e. prefer "Failure", "Exception", "Unknown", "Success" in that order)
+            const job_lastBuildStatus = xitems[job_name].lastBuildStatus;
+            if (job_lastBuildStatus === "Failure" ||
+                (job_lastBuildStatus === "Exception" && box.lastBuildStatus !== "Failure") ||
+                (job_lastBuildStatus === "Unknown" && box.lastBuildStatus !== "Failure" && box.lastBuildStatus !== "Exception")
+               ) {
+                box.lastBuildStatus = job_lastBuildStatus;
+            }
+            // override activity if this job's activity is more active than the existing one (i.e. prefer "Building", "Pending", "CheckingModifications", "Sleeping" in that order)
+            const job_activity = xitems[job_name].activity;
+            if (job_activity == "Building" ||
+                (job_activity == "Pending" && box.activity != "Building") ||
+                (job_activity == "CheckingModifications" && box.activity != "Building" && box.activity != "Pending")
+               ) {
+                box.activity = job_activity;
+            }
+        });
+        return box;
+    }
+
 	  function loadDashboard(config, dlist, idx, max, delay, blank) {
 		    dashboard = config.dashboard[dlist[idx]];
 		    loadRemoteURL(dashboard.url, dashboard.access, 'application/xml', function(ctx) {
@@ -212,26 +235,7 @@
             var boxes = [];
             if (show.pipelines) {
                 for (pipeline in pipelines) {
-                    const job_names = pipelines[pipeline];
-                    var box = xitem[job_names[0]]; // initialize box to the first job in the pipelines
-                    job_names.slice(1).forEach(function(job_name) {
-                        // override box if this job's lastBuildStatus is more fail-y than the existing one (i.e. prefer "Failure", "Exception", "Unknown", "Success" in that order) 
-                        const job_lastBuildStatus = xitem[job_name].lastBuildStatus;
-                        if (job_lastBuildStatus == "Failure" ||
-                            (job_lastBuildStatus == "Exception" && box.lastBuildStatus != "Failure") ||
-                            (job_lastBuildStatus == "Unknown" && box.lastBuildStatus != "Failure" && box.lastBuildStatus != "Exception")
-                           ) {
-                            box.lastBuildStatus = job_lastBuildStatus;
-                        }
-                        // override activity if this job's activity is more active than the existing one (i.e. prefer "Building", "Pending", "CheckingModifications", "Sleeping" in that order)
-                        const job_activity = xitem[job_name].activity;
-                        if (job_activity == "Building" ||
-                            (job_activity == "Pending" && box.activity != "Building") ||
-                            (job_activity == "CheckingModifications" && box.activity != "Building" && box.activity != "Pending")
-                           ) {
-                            box.activity = job_activity;
-                        }
-                    });
+                    const box = boxFromJobs(pipelines[pipeline], xitem);
                     // override displayName with name of pipeline instead of name of job
                     box.displayName = pipeline;
                     boxes.push(box);
@@ -239,26 +243,7 @@
             }
             if (show.stages) {
                 for (stage in stages) {
-                    const job_names = stages[stage];
-                    var box = xitem[job_names[0]]; // initialize box to the first job in the stages
-                    job_names.slice(1).forEach(function(job_name) {
-                        // override box if this job's lastBuildStatus is more fail-y than the existing one (i.e. prefer "Failure", "Exception", "Unknown", "Success" in that order)
-                        const job_lastBuildStatus = xitem[job_name].lastBuildStatus;
-                        if (job_lastBuildStatus == "Failure" ||
-                            (job_lastBuildStatus == "Exception" && box.lastBuildStatus != "Failure") ||
-                            (job_lastBuildStatus == "Unknown" && box.lastBuildStatus != "Failure" && box.lastBuildStatus != "Exception")
-                           ) {
-                            box.lastBuildStatus = job_lastBuildStatus;
-                        }
-                        // override activity if this job's activity is more active than the existing one (i.e. prefer "Building", "Pending", "CheckingModifications", "Sleeping" in that order)
-                        const job_activity = xitem[job_name].activity;
-                        if (job_activity == "Building" ||
-                            (job_activity == "Pending" && box.activity != "Building") ||
-                            (job_activity == "CheckingModifications" && box.activity != "Building" && box.activity != "Pending")
-                           ) {
-                            box.activity = job_activity;
-                        }
-                    });
+                    const box = boxFromJobs(stages[stage], xitem);
                     // override displayName with name of stage instead of name of job
                     box.displayName = stage;
                     boxes.push(box);

--- a/src/static/js/web-cctray.js
+++ b/src/static/js/web-cctray.js
@@ -185,33 +185,81 @@
                 // split name into pipeline, stage, and job components
                 const psj = name.split("::").map(function(s){return s.trim()})
                 const pipeline = psj[0];
-                if (!(pipeline in pipelines)) {
-                    pipelines[pipeline] = name;
+                // store list of job names in pipelines[pipeline]
+                if (pipeline in pipelines) {
+                    pipelines[pipeline].push(name);
+                } else {
+                    pipelines[pipeline] = [name];
                 }
                 if (psj.length > 1) {
                     const stage = psj.slice(0,2).join("::");
-                    if (!(stage in stages)) {
-                        stages[stage] = name;
+                    // store list of job names in stages[stage]
+                    if (stage in stages) {
+                        stages[stage].push(name);
+                    } else {
+                        stages[stage] = [name];
                     }
                 }
                 if (psj.length > 2) {
                     const job = psj.join("::");
                     if (!(job in jobs)) {
                         jobs[job] = name;
+                    } else {
+                        console.error(`Multiple entries for job ${job}`);
                     }
 			          }
             }
             var boxes = [];
             if (show.pipelines) {
                 for (pipeline in pipelines) {
-                    const box = xitem[pipelines[pipeline]];
+                    const job_names = pipelines[pipeline];
+                    var box = xitem[job_names[0]]; // initialize box to the first job in the pipelines
+                    job_names.slice(1).forEach(function(job_name) {
+                        // override box if this job's lastBuildStatus is more fail-y than the existing one (i.e. prefer "Failure", "Exception", "Unknown", "Success" in that order) 
+                        const job_lastBuildStatus = xitem[job_name].lastBuildStatus;
+                        if (job_lastBuildStatus == "Failure" ||
+                            (job_lastBuildStatus == "Exception" && box.lastBuildStatus != "Failure") ||
+                            (job_lastBuildStatus == "Unknown" && box.lastBuildStatus != "Failure" && box.lastBuildStatus != "Exception")
+                           ) {
+                            box.lastBuildStatus = job_lastBuildStatus;
+                        }
+                        // override activity if this job's activity is more active than the existing one (i.e. prefer "Building", "Pending", "CheckingModifications", "Sleeping" in that order)
+                        const job_activity = xitem[job_name].activity;
+                        if (job_activity == "Building" ||
+                            (job_activity == "Pending" && box.activity != "Building") ||
+                            (job_activity == "CheckingModifications" && box.activity != "Building" && box.activity != "Pending")
+                           ) {
+                            box.activity = job_activity;
+                        }
+                    });
+                    // override displayName with name of pipeline instead of name of job
                     box.displayName = pipeline;
                     boxes.push(box);
                 }
             }
             if (show.stages) {
                 for (stage in stages) {
-                    const box = xitem[stages[stage]];
+                    const job_names = stages[stage];
+                    var box = xitem[job_names[0]]; // initialize box to the first job in the stages
+                    job_names.slice(1).forEach(function(job_name) {
+                        // override box if this job's lastBuildStatus is more fail-y than the existing one (i.e. prefer "Failure", "Exception", "Unknown", "Success" in that order)
+                        const job_lastBuildStatus = xitem[job_name].lastBuildStatus;
+                        if (job_lastBuildStatus == "Failure" ||
+                            (job_lastBuildStatus == "Exception" && box.lastBuildStatus != "Failure") ||
+                            (job_lastBuildStatus == "Unknown" && box.lastBuildStatus != "Failure" && box.lastBuildStatus != "Exception")
+                           ) {
+                            box.lastBuildStatus = job_lastBuildStatus;
+                        }
+                        // override activity if this job's activity is more active than the existing one (i.e. prefer "Building", "Pending", "CheckingModifications", "Sleeping" in that order)
+                        const job_activity = xitem[job_name].activity;
+                        if (job_activity == "Building" ||
+                            (job_activity == "Pending" && box.activity != "Building") ||
+                            (job_activity == "CheckingModifications" && box.activity != "Building" && box.activity != "Pending")
+                           ) {
+                            box.activity = job_activity;
+                        }
+                    });
+                    // override displayName with name of stage instead of name of job
                     box.displayName = stage;
                     boxes.push(box);
                 }
@@ -267,8 +315,8 @@
 					          rowDiv.style.height = rowHeight+'px';
 					          setCols = 0;
 				        }
-				        var name = boxes[pi].displayName;
                 var box = boxes[pi];
+				        var name = box.displayName;
 				        var title = name;
                 for (const stripname of stripnames.split(",")) {
                     title = title.replace(stripname, '');


### PR DESCRIPTION
make pipeline and stage boxes display the worst (most fail-y) job status within them and the most active job activity within them. 